### PR TITLE
ls-config-check: Allow multiple input filenames

### DIFF
--- a/cmd/ls-config-check/README.md
+++ b/cmd/ls-config-check/README.md
@@ -1,6 +1,6 @@
 # ls-config-check
 
-`cmd/ls-config-check` contains the source code for a small sample tool, which uses just allow to parse a given Logstash config file. If the file could be parsed successfully, the tool just exits with exit code `0`. If the parsing fails, the exit code is non zero and a error message, indicating the location, where the parsing failed, is printed.
+`cmd/ls-config-check` contains the source code for a small sample tool, which uses just allow to parse one or more given Logstash config files. If all files could be parsed successfully, the tool just exits with exit code `0`. If the parsing fails, the exit code is non zero and a error message, indicating the location, where the parsing failed, is printed.
 `ls-config-check <logstash-config-file>` could be used instead if `bin/logstash -f <logstash-config-file> -t`, which is orders of magnitude faster 😃. 
 
 ## Install


### PR DESCRIPTION
Perform the syntax check on all given filename arguments and exit non-zero if any of them failed.