### PR TITLE
Fix hashentry name

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -549,15 +549,24 @@ func (ha HashAttribute) Value() []HashEntry {
 	return ha.value
 }
 
+type HashEntryKey interface {
+	ValueString() string
+	attributeNode()
+	hashEntryKeyAttribute()
+}
+
+func (NumberAttribute) hashEntryKeyAttribute() {}
+func (StringAttribute) hashEntryKeyAttribute() {}
+
 // A HashEntry node defines a hash entry within a hash attribute.
 type HashEntry struct {
-	name    string
+	name    HashEntryKey
 	value   Attribute
 	Comment CommentBlock
 }
 
 // NewHashEntry creates a new hash entry for a hash attribute.
-func NewHashEntry(name string, value Attribute) HashEntry {
+func NewHashEntry(name HashEntryKey, value Attribute) HashEntry {
 	return HashEntry{
 		name:  name,
 		value: value,
@@ -566,7 +575,7 @@ func NewHashEntry(name string, value Attribute) HashEntry {
 
 // Name returns the name of the attribute.
 func (he HashEntry) Name() string {
-	return he.name
+	return he.name.ValueString()
 }
 
 // String returns a string representation of a hash entry.

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -27,8 +27,10 @@ func TestAst(t *testing.T) {
 						),
 						NewHashAttribute(
 							"add_field",
-							NewHashEntry("fieldname", NewStringAttribute("", "fieldvalue", DoubleQuoted)),
-							NewHashEntry("number", NewNumberAttribute("", 3.1415)),
+							NewHashEntry(NewStringAttribute("", "bareword", Bareword), NewStringAttribute("", "bareword", Bareword)),
+							NewHashEntry(NewStringAttribute("", "single quoted", SingleQuoted), NewStringAttribute("", "single quoted", SingleQuoted)),
+							NewHashEntry(NewStringAttribute("", "double quoted", DoubleQuoted), NewStringAttribute("", "double quoted", DoubleQuoted)),
+							NewHashEntry(NewNumberAttribute("", 1), NewNumberAttribute("", 3.1415)),
 						),
 						NewNumberAttribute("pi", 3.1415),
 						NewPluginAttribute("codec", NewPlugin("rubydebug", NewStringAttribute("string", "a value", DoubleQuoted))),
@@ -49,8 +51,10 @@ func TestAst(t *testing.T) {
       tag3
     ]
     add_field => {
-      fieldname => "fieldvalue"
-      number => 3.1415
+      bareword => bareword
+      'single quoted' => 'single quoted'
+      "double quoted" => "double quoted"
+      1 => 3.1415
     }
     pi => 3.1415
     codec => rubydebug {
@@ -531,7 +535,7 @@ output {
 						nil,
 						NewStringAttribute("foo", "bar", Bareword),
 						NewArrayAttribute("nil", nil),
-						NewHashAttribute("nilHash", NewHashEntry("nilEntry", nil)),
+						NewHashAttribute("nilHash", NewHashEntry(NewStringAttribute("", "nilEntry", Bareword), nil)),
 						nil,
 					),
 					NewBranch(

--- a/logstash_config_helper.go
+++ b/logstash_config_helper.go
@@ -335,14 +335,9 @@ func hashentries(attribute, attributes1 interface{}) ([]ast.HashEntry, error) {
 }
 
 func hashentry(name, value, comment interface{}) (ast.HashEntry, error) {
-	var key ast.StringAttribute
+	key := name.(ast.HashEntryKey)
 
-	switch name := name.(type) {
-	case ast.StringAttribute:
-		key = name
-	}
-
-	he := ast.NewHashEntry(key.ValueString(), value.(ast.Attribute))
+	he := ast.NewHashEntry(key, value.(ast.Attribute))
 	he.Comment = commentBlock(comment, true, false)
 
 	return he, nil


### PR DESCRIPTION
hashentry name are allowed to be numbers, single- and double-quoted strings as well