### PR TITLE
add Value() method to PluginAttribute struct

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -368,6 +368,10 @@ func (pa PluginAttribute) CommentBlock() string {
 	return pa.Comment.String()
 }
 
+func (pa PluginAttribute) Value() Plugin {
+	return pa.value
+}
+
 const (
 	// Undefined is already defined
 


### PR DESCRIPTION
Only for the PluginAttribute structure the Value() method was not defined and I could not get the value of the Plugin, so I added a method.

If there is no reason why the Value() method does not exist only for PluginAttribute, I would be happy to have it merged.
